### PR TITLE
unified conventions

### DIFF
--- a/API_MO/conventions/FreeFieldDirectivityTF_1.0.csv
+++ b/API_MO/conventions/FreeFieldDirectivityTF_1.0.csv
@@ -1,62 +1,62 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm		attribute	
-GLOBAL:Version	2.0	rm		attribute	
+GLOBAL:Conventions	SOFA	rm		attribute
+GLOBAL:Version	2.0	rm		attribute
 GLOBAL:SOFAConventions	FreeFieldDirectivityTF	rm		attribute	This conventions stores directivities of acoustic sources (instruments, loudspeakers, singers, talkers, etc) in the frequency domain for multiple musical notes in free field.
-GLOBAL:SOFAConventionsVersion	1.0	rm		attribute	
+GLOBAL:SOFAConventionsVersion	1.0	rm		attribute
 GLOBAL:DataType	TF	rm		attribute	We store frequency-dependent data here
 GLOBAL:RoomType	free field	m		attribute	The room information can be arbitrary, but the spatial setup assumes free field.
-GLOBAL:Title		m		attribute	
-GLOBAL:DateCreated		m		attribute	
-GLOBAL:DateModified		m		attribute	
-GLOBAL:APIName		rm		attribute	
-GLOBAL:APIVersion		rm		attribute	
-GLOBAL:AuthorContact		m		attribute	
-GLOBAL:Organization		m		attribute	
-GLOBAL:License	No license provided, ask the author for permission	m		attribute	
-GLOBAL:ApplicationName				attribute	
-GLOBAL:ApplicationVersion				attribute	
-GLOBAL:Comment		m		attribute	
-GLOBAL:History				attribute	
-GLOBAL:References				attribute	
-GLOBAL:Origin				attribute	
+GLOBAL:Title		m		attribute
+GLOBAL:DateCreated		m		attribute
+GLOBAL:DateModified		m		attribute
+GLOBAL:APIName		rm		attribute
+GLOBAL:APIVersion		rm		attribute
+GLOBAL:AuthorContact		m		attribute
+GLOBAL:Organization		m		attribute
+GLOBAL:License	No license provided, ask the author for permission	m		attribute
+GLOBAL:ApplicationName				attribute
+GLOBAL:ApplicationVersion				attribute
+GLOBAL:Comment		m		attribute
+GLOBAL:History				attribute
+GLOBAL:References				attribute
+GLOBAL:Origin				attribute
 GLOBAL:DatabaseName		m		attribute	Name of the database. Used for classification of the data
 GLOBAL:Musician				attribute	Narrative description of the musician such as position, behavior, or personal data if not data-protected, e.g., 'Christiane Schmidt sitting on the chair', or 'artificial excitation by R2D2'.
 GLOBAL:Description				attribute	Narrative description of a measurement. For musical instruments/singers, the note (C1, D1, etc) or the dynamic (pp., ff., etc), or the string played, the playing style (pizzicato, legato, etc.), or the type of excitation (e.g., hit location of a cymbal). For loudspeakers, the system and driver units.
-GLOBAL:SourceType		m		attribute	Narrative description of the acoustic source, e.g., 'Violin', 'Female singer', or ‘2-way loudspeaker
-GLOBAL:SourceManufacturer		m		attribute	Narrative description of the manufacturer of the source, e.g., 'Stradivari, Lady Blunt, 1721' or ‘LoudspeakerCompany’
+GLOBAL:SourceType		m		attribute	Narrative description of the acoustic source, e.g., 'Violin', 'Female singer', or '2-way loudspeaker'
+GLOBAL:SourceManufacturer		m		attribute	Narrative description of the manufacturer of the source, e.g., 'Stradivari, Lady Blunt, 1721' or 'LoudspeakerCompany'
 ListenerPosition	[0 0 0] 	m	IC, MC	double	Position of the microphone array during the measurements.
-ListenerPosition:Type	cartesian	m		attribute	
-ListenerPosition:Units	metre	m		attribute	
+ListenerPosition:Type	cartesian	m		attribute
+ListenerPosition:Units	metre	m		attribute
 ListenerView	[1 0 0]	m	IC, MC	double	Orientation of the microphone array
-ListenerView:Type	cartesian	m		attribute	
-ListenerView:Units	metre	m		attribute	
+ListenerView:Type	cartesian	m		attribute
+ListenerView:Units	metre	m		attribute
 ListenerUp	[0 0 1]	m	IC, MC	double	Up vector of the microphone array
-ListenerUp:Type	cartesian	m		attribute	
-ListenerUp:Units	metre	m		attribute	
+ListenerUp:Type	cartesian	m		attribute
+ListenerUp:Units	metre	m		attribute
 ReceiverPosition	[0 0 1]	m	IC, RC, RCM	double	Positions of the microphones during the measurements (relative to the Listener)
-ReceiverPosition:Type	spherical	m		attribute	
-ReceiverPosition:Units	degree, degree, metre	m		attribute	
+ReceiverPosition:Type	spherical	m		attribute
+ReceiverPosition:Units	degree, degree, metre	m		attribute
 SourcePosition	[0 0 0] 	m	IC, MC	double	Position of the acoustic source (instrument)
-SourcePosition:Type	cartesian	m		attribute	
-SourcePosition:Units	metre	m		attribute	
-SourcePosition:Reference		m		attribute	Narrative description of the spatial reference of the source position, e.g., for the trumpet, ‘The bell’. Mandatory in order to provide a reference across different instruments
+SourcePosition:Type	cartesian	m		attribute
+SourcePosition:Units	metre	m		attribute
+SourcePosition:Reference		m		attribute	Narrative description of the spatial reference of the source position, e.g., for the trumpet, 'The bell'. Mandatory in order to provide a reference across different instruments
 SourceView	[1 0 0]	m	IC, MC	double	Orientation of the acoustic source (instrument)
-SourceView:Type	cartesian	m		attribute	
-SourceView:Units	metre	m		attribute	
-SourceView:Reference		m		attribute	Narrative description of the spatial reference of the source view, e.g., for the trumpet, ‘Viewing direction of the bell’. Mandatory in order to provide a reference across different instruments
+SourceView:Type	cartesian	m		attribute
+SourceView:Units	metre	m		attribute
+SourceView:Reference		m		attribute	Narrative description of the spatial reference of the source view, e.g., for the trumpet, 'Viewing direction of the bell'. Mandatory in order to provide a reference across different instruments
 SourceUp	[0 0 1]	m	IC, MC	double	Up vector of the acoustic source (instrument)
-SourceUp:Type	cartesian	m		attribute	
-SourceUp:Units	metre	m		attribute	
-SourceUp:Reference		m		attribute	Narrative description of the spatial reference of the source up, e.g., for the trumpet, ‘Along the keys, keys up’. Mandatory in order to provide a reference across different instruments
+SourceUp:Type	cartesian	m		attribute
+SourceUp:Units	metre	m		attribute
+SourceUp:Reference		m		attribute	Narrative description of the spatial reference of the source up, e.g., for the trumpet, 'Along the keys, keys up'. Mandatory in order to provide a reference across different instruments
 EmitterPosition	[0 0 0]	m	IC, MC	double	A more detailed structure of the Source. In a simple settings, a single Emitter is considered that is collocated with the source.
-EmitterPosition:Type	cartesian	m		attribute	
-EmitterPosition:Units	metre	m		attribute	
+EmitterPosition:Type	cartesian	m		attribute
+EmitterPosition:Units	metre	m		attribute
 EmitterDescription			IS, MS	attribute	A more detailed structure of the source. In a simple setting, a single Emitter is considered that is collocated with the source. In a more complicated setting, this may be the strings of a violin or the units of a loudspeaker.
 MIDINote	0		I, M	double	Defines the note played by the source during the measurement. The note is specified a MIDI note by the [https://www.midi.org/specifications-old/item/the-midi-1-0-specification MIDI specifications, version 1.0]. Not mandatory, but recommended for tonal instruments.
 Description			MS	attribute	This variable is used when the description varies with M.
-SourceTuningFrequency			I, M	double	Frequency (in Hertz) to which a musical instrument is tuned to corresponding to the note A4 (MIDINote=69). Recommended for tonal instruments.
+SourceTuningFrequency	440		I, M	double	Frequency (in Hertz) to which a musical instrument is tuned to corresponding to the note A4 (MIDINote=69). Recommended for tonal instruments.
 Data.Real	0	m	mrn	double	Real part of the complex spectrum. The default value 0 indicates that all data fields are initialized with zero values.
 Data.Imag	0	m	MRN	double	Imaginary part of the complex spectrum
 N	0	m	N	double	Frequency values
-N:LongName	frequency	m		attribute	
+N:LongName	frequency	m		attribute
 N:Units	Hertz	m		attribute	Units used for N

--- a/API_MO/conventions/FreeFieldHRTF_1.0.csv
+++ b/API_MO/conventions/FreeFieldHRTF_1.0.csv
@@ -1,44 +1,44 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	2	rm	 	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	2	rm	 	attribute
 GLOBAL:SOFAConventions	FreeFieldHRTF	rm	  	attribute	This conventions is for HRTFs created under conditions where room information is irrelevant and stored as SH coefficients
-GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Comment			 	attribute	
-GLOBAL:DataType	TF-E	rm	  	attribute	
-GLOBAL:History			 	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
+GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Comment			 	attribute
+GLOBAL:DataType	TF-E	rm	  	attribute
+GLOBAL:History			 	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
 GLOBAL:ListenerShortName		m		attribute	ID of the subject from the database
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:References				attribute	
-GLOBAL:RoomType	free field	m	  	attribute	
-GLOBAL:Origin				attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:Title		m		attribute	
-ListenerPosition	[0 0 0] 	m	IC, MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	RCI, RCM	double	
-ReceiverPosition:Type	cartesian	m	  	attribute	
-ReceiverPosition:Units	metre	m	  	attribute	
+GLOBAL:Organization		m	  	attribute
+GLOBAL:References				attribute
+GLOBAL:RoomType	free field	m	  	attribute
+GLOBAL:Origin				attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:Title		m		attribute
+ListenerPosition	[0 0 0] 	m	IC, MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	RCI, RCM	double
+ReceiverPosition:Type	cartesian	m	  	attribute
+ReceiverPosition:Units	metre	m	  	attribute
 SourcePosition	[0 0 0]	m	IC, MC	double	Source position is assumed to be the ListenerPosition in order to reflect Emitters surrounding the Listener
-SourcePosition:Type	spherical	m	  	attribute	
-SourcePosition:Units	degree, degree, metre	m	  	attribute	
-EmitterPosition	[0 0 0]	m	IC, ECI, ECM	double	Radius in ‘spherical harmonics’, Position in ‘cartesian’ and ‘spherical’
-EmitterPosition:Type	spherical harmonics	m	  	attribute	Can be ‘spherical harmonics’, ‘cartesian’, or ‘spherical’
-EmitterPosition:Units	degree, degree, metre	m	  	attribute	
+SourcePosition:Type	spherical	m	  	attribute
+SourcePosition:Units	degree, degree, metre	m	  	attribute
+EmitterPosition	[0 0 0]	m	IC, ECI, ECM	double	Radius in 'spherical harmonics', Position in 'cartesian' and 'spherical'
+EmitterPosition:Type	spherical harmonics	m	  	attribute	Can be 'spherical harmonics', 'cartesian', or 'spherical'
+EmitterPosition:Units	degree, degree, metre	m	  	attribute
 GLOBAL:DatabaseName		m	  	attribute	Name of the database to which these data belong
-ListenerUp	[0 0 1]	m	IC, MC	double	
-ListenerView	[1 0 0]	m	IC, MC	double	
-ListenerView:Type	cartesian	m		attribute	
-ListenerView:Units	metre	m		attribute	
-Data.Real	[0 0]	m	mrne	double	
-Data.Imag	[0 0]	m	MRNE	double	
-N	0	m	N	double	
-N_LongName	frequency			attribute	
-N_Units	hertz			attribute	
+ListenerUp	[0 0 1]	m	IC, MC	double
+ListenerView	[1 0 0]	m	IC, MC	double
+ListenerView:Type	cartesian	m		attribute
+ListenerView:Units	metre	m		attribute
+Data.Real	[0 0]	m	mrne	double
+Data.Imag	[0 0]	m	MRNE	double
+N	0	m	N	double
+N:LongName	frequency			attribute
+N:Units	hertz			attribute

--- a/API_MO/conventions/GeneralFIR-E_2.0.csv
+++ b/API_MO/conventions/GeneralFIR-E_2.0.csv
@@ -1,36 +1,36 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	2.0	rm	 	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	2.0	rm	 	attribute
 GLOBAL:SOFAConventions	GeneralFIR-E	rm	  	attribute	This conventions stores IRs for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined
-GLOBAL:SOFAConventionsVersion	2.0	rm	  	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Comment		m	 	attribute	
+GLOBAL:SOFAConventionsVersion	2.0	rm	  	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Comment		m	 	attribute
 GLOBAL:DataType	FIR-E	rm	  	attribute	We use FIR datatype which in addition depends on Emitters (E)
-GLOBAL:History			 	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:References				attribute	
+GLOBAL:History			 	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:References				attribute
 GLOBAL:RoomType	free field	m	  	attribute	The room information can be arbitrary
-GLOBAL:Origin				attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:Title		m		attribute	
-ListenerPosition	[0 0 0] 	m	IC, MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ReceiverPosition	[0 0 0]	m	I, R, M, RM, RCI, RCM	double	
-ReceiverPosition:Type	cartesian	m	  	attribute	
-ReceiverPosition:Units	metre	m	  	attribute	
-SourcePosition	[0 0 1]	m	IC, MC	double	
-SourcePosition:Type	spherical	m	  	attribute	
-SourcePosition:Units	degree, degree, metre	m	  	attribute	
-EmitterPosition	[0 0 0]	m	I, E, M, EM, ECI, ECM	double	Each speaker is represented as an emitter. Use EmitterPosition to represent the position of a particular speaker. Size of EmitterPosition determines E
-EmitterPosition:Type	cartesian	m	  	attribute	
-EmitterPosition:Units	metre	m	  	attribute	
+GLOBAL:Origin				attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:Title		m		attribute
+ListenerPosition	[0 0 0] 	m	IC, MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ReceiverPosition	[0 0 0]	m	IC, RC, RCM	double
+ReceiverPosition:Type	cartesian	m	  	attribute
+ReceiverPosition:Units	metre	m	  	attribute
+SourcePosition	[0 0 1]	m	IC, MC	double
+SourcePosition:Type	spherical	m	  	attribute
+SourcePosition:Units	degree, degree, metre	m	  	attribute
+EmitterPosition	[0 0 0]	m	IC, EC, ECM	double	Each speaker is represented as an emitter. Use EmitterPosition to represent the position of a particular speaker. Size of EmitterPosition determines E
+EmitterPosition:Type	cartesian	m	  	attribute
+EmitterPosition:Units	metre	m	  	attribute
 Data.IR	0	m	mrne	double	Impulse responses
 Data.SamplingRate	48000	m	I, M	double	Sampling rate of the samples in Data.IR and Data.Delay
 Data.SamplingRate:Units	hertz	m		attribute	Unit of the sampling rate

--- a/API_MO/conventions/GeneralFIR_2.0.csv
+++ b/API_MO/conventions/GeneralFIR_2.0.csv
@@ -1,40 +1,40 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	2.0	rm	 	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	2.0	rm	 	attribute
 GLOBAL:SOFAConventions	GeneralFIR	rm	  	attribute	This conventions stores IRs for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined
-GLOBAL:SOFAConventionsVersion	2.0	rm	  	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Comment		m	 	attribute	
+GLOBAL:SOFAConventionsVersion	2.0	rm	  	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Comment		m	 	attribute
 GLOBAL:DataType	FIR	rm	  	attribute	We store IRs here
-GLOBAL:History			 	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:References				attribute	
+GLOBAL:History			 	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:References				attribute
 GLOBAL:RoomType	free field	m	  	attribute	The room information can be arbitrary
-GLOBAL:Origin				attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:Title		m		attribute	
-ListenerPosition	[0 0 0] 	m	IC, MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ReceiverPosition	[0 0 0]	m	I, R, IM, RM, RCI, RCM	double	
-ReceiverPosition:Type	cartesian	m	  	attribute	
-ReceiverPosition:Units	metre	m	  	attribute	
+GLOBAL:Origin				attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:Title		m		attribute
+ListenerPosition	[0 0 0] 	m	IC, MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ReceiverPosition	[0 0 0]	m	IC, RC, RCM	double
+ReceiverPosition:Type	cartesian	m	  	attribute
+ReceiverPosition:Units	metre	m	  	attribute
 SourcePosition	[0 0 1]	m	IC, MC	double	In order to store different directions/positions around the listener, SourcePosition is assumed to vary
-SourcePosition:Type	spherical	m	  	attribute	
-SourcePosition:Units	degree, degree, metre	m	  	attribute	
-EmitterPosition	[0 0 0]	m	eCI, eCM	double	
-EmitterPosition:Type	cartesian	m	  	attribute	
-EmitterPosition:Units	metre	m	  	attribute	
+SourcePosition:Type	spherical	m	  	attribute
+SourcePosition:Units	degree, degree, metre	m	  	attribute
+EmitterPosition	[0 0 0]	m	eCI, eCM	double
+EmitterPosition:Type	cartesian	m	  	attribute
+EmitterPosition:Units	metre	m	  	attribute
 Data.IR	0	m	mrn	double	Impulse responses
 Data.SamplingRate	48000	m	I, M	double	Sampling rate of the samples in Data.IR and Data.Delay
 Data.SamplingRate:Units	hertz	m		attribute	Unit of the sampling rate
 Data.Delay	0	m	IR, MR	double	Additional delay of each IR (in samples)
-ListenerView	[1 0 0]		IC, MC	double	
-ListenerView:Type	cartesian			attribute	
-ListenerView:Units	metre			attribute	
+ListenerView	[1 0 0]		IC, MC	double
+ListenerView:Type	cartesian			attribute
+ListenerView:Units	metre			attribute

--- a/API_MO/conventions/GeneralTF-E_1.0.csv
+++ b/API_MO/conventions/GeneralTF-E_1.0.csv
@@ -1,38 +1,38 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	2.0	rm	 	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	2.0	rm	 	attribute
 GLOBAL:SOFAConventions	GeneralTF-E	rm	  	attribute	This conventions stores TFs depending in the Emiiter for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined. This convention is based on GeneralTF
-GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Comment		m	 	attribute	
+GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Comment		m	 	attribute
 GLOBAL:DataType	TF-E	rm	  	attribute	We store frequency-dependent data depending on the emitter here
-GLOBAL:History			 	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:References				attribute	
+GLOBAL:History			 	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:References				attribute
 GLOBAL:RoomType	free field	m	  	attribute	The room information can be arbitrary
-GLOBAL:Origin				attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:Title		m		attribute	
-ListenerPosition	[0 0 0] 	m	IC, MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ReceiverPosition	[0 0 0]	m	I, R, M, RM, RCI, RCM	double	
-ReceiverPosition:Type	cartesian	m	  	attribute	
-ReceiverPosition:Units	metre	m	  	attribute	
+GLOBAL:Origin				attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:Title		m		attribute
+ListenerPosition	[0 0 0] 	m	IC, MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ReceiverPosition	[0 0 0]	m	IC, RC, RCM	double
+ReceiverPosition:Type	cartesian	m	  	attribute
+ReceiverPosition:Units	metre	m	  	attribute
 SourcePosition	[0 0 1]	m	IC, MC	double	In order to store different directions/positions around the listener, SourcePosition is assumed to vary
-SourcePosition:Type	spherical	m	  	attribute	
-SourcePosition:Units	degree, degree, metre	m	  	attribute	
-EmitterPosition	[0 0 0]	m	I, E, M, EM, ECI, ECM	double	
-EmitterPosition:Type	cartesian	m	  	attribute	
-EmitterPosition:Units	metre	m	  	attribute	
+SourcePosition:Type	spherical	m	  	attribute
+SourcePosition:Units	degree, degree, metre	m	  	attribute
+EmitterPosition	[0 0 0]	m	IC, EC, ECM	double
+EmitterPosition:Type	cartesian	m	  	attribute
+EmitterPosition:Units	metre	m	  	attribute
 Data.Real	0	m	mrne	double	The real part of the complex spectrum
 Data.Imag	0	m	MRNE	double	The imaginary part of the complex spectrum
 N	0	m	N	double	Frequency values
-N_LongName	frequency			attribute	
-N_Units	hertz	m		attribute	Unit of the values given in N
+N:LongName	frequency			attribute
+N:Units	hertz	m		attribute	Unit of the values given in N

--- a/API_MO/conventions/GeneralTF_1.0.csv
+++ b/API_MO/conventions/GeneralTF_1.0.csv
@@ -1,38 +1,38 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	1.0	rm	 	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	1.0	rm	 	attribute
 GLOBAL:SOFAConventions	GeneralTF	rm	  	attribute	This conventions stores TFs for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined. This convention is based on GeneralFIR.
-GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Comment		m	 	attribute	
+GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Comment		m	 	attribute
 GLOBAL:DataType	TF	rm	  	attribute	We store frequency-dependent data here
-GLOBAL:History			 	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:References				attribute	
+GLOBAL:History			 	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:References				attribute
 GLOBAL:RoomType	free field	m	  	attribute	The room information can be arbitrary
-GLOBAL:Origin				attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:Title		m		attribute	
-ListenerPosition	[0 0 0] 	m	IC, MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ReceiverPosition	[0 0 0]	m	rCI, rCM	double	
-ReceiverPosition:Type	cartesian	m	  	attribute	
-ReceiverPosition:Units	metre	m	  	attribute	
+GLOBAL:Origin				attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:Title		m		attribute
+ListenerPosition	[0 0 0] 	m	IC, MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ReceiverPosition	[0 0 0]	m	rCI, rCM	double
+ReceiverPosition:Type	cartesian	m	  	attribute
+ReceiverPosition:Units	metre	m	  	attribute
 SourcePosition	[0 0 1]	m	IC, MC	double	In order to store different directions/positions around the listener, SourcePosition is assumed to vary
-SourcePosition:Type	spherical	m	  	attribute	
-SourcePosition:Units	degree, degree, metre	m	  	attribute	
-EmitterPosition	[0 0 0]	m	eCI, eCM	double	
-EmitterPosition:Type	cartesian	m	  	attribute	
-EmitterPosition:Units	metre	m	  	attribute	
+SourcePosition:Type	spherical	m	  	attribute
+SourcePosition:Units	degree, degree, metre	m	  	attribute
+EmitterPosition	[0 0 0]	m	eCI, eCM	double
+EmitterPosition:Type	cartesian	m	  	attribute
+EmitterPosition:Units	metre	m	  	attribute
 Data.Real	0	m	mRn	double	The real part of the complex spectrum
 Data.Imag	0	m	MRN	double	The imaginary part of the complex spectrum
 N	0	m	N	double	Frequency values
-N_LongName	frequency			attribute	
-N_Units	hertz	m		attribute	Unit of the values given in N
+N:LongName	frequency			attribute
+N:Units	hertz	m		attribute	Unit of the values given in N

--- a/API_MO/conventions/GeneralTF_2.0.csv
+++ b/API_MO/conventions/GeneralTF_2.0.csv
@@ -1,38 +1,38 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	1.0	rm	 	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	1.0	rm	 	attribute
 GLOBAL:SOFAConventions	GeneralTF	rm	  	attribute	This conventions stores TFs for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined. This convention is based on GeneralFIR.
-GLOBAL:SOFAConventionsVersion	2.0	rm	  	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Comment		m	 	attribute	
+GLOBAL:SOFAConventionsVersion	2.0	rm	  	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Comment		m	 	attribute
 GLOBAL:DataType	TF	rm	  	attribute	We store frequency-dependent data here
-GLOBAL:History			 	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:References				attribute	
+GLOBAL:History			 	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:References				attribute
 GLOBAL:RoomType	free field	m	  	attribute	The room information can be arbitrary
-GLOBAL:Origin				attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:Title		m		attribute	
-ListenerPosition	[0 0 0] 	m	IC, MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ReceiverPosition	[0 0 0]	m	I, R, IM, RM, RCI, RCM	double	
-ReceiverPosition:Type	cartesian	m	  	attribute	
-ReceiverPosition:Units	metre	m	  	attribute	
+GLOBAL:Origin				attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:Title		m		attribute
+ListenerPosition	[0 0 0] 	m	IC, MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ReceiverPosition	[0 0 0]	m	IC, RC, RCM	double
+ReceiverPosition:Type	cartesian	m	  	attribute
+ReceiverPosition:Units	metre	m	  	attribute
 SourcePosition	[0 0 1]	m	IC, MC	double	In order to store different directions/positions around the listener, SourcePosition is assumed to vary
-SourcePosition:Type	spherical	m	  	attribute	
-SourcePosition:Units	degree, degree, metre	m	  	attribute	
-EmitterPosition	[0 0 0]	m	eCI, eCM	double	
-EmitterPosition:Type	cartesian	m	  	attribute	
-EmitterPosition:Units	metre	m	  	attribute	
+SourcePosition:Type	spherical	m	  	attribute
+SourcePosition:Units	degree, degree, metre	m	  	attribute
+EmitterPosition	[0 0 0]	m	eCI, eCM	double
+EmitterPosition:Type	cartesian	m	  	attribute
+EmitterPosition:Units	metre	m	  	attribute
 Data.Real	0	m	mrn	double	The real part of the complex spectrum
 Data.Imag	0	m	MRN	double	The imaginary part of the complex spectrum
 N	0	m	N	double	Frequency values
-N_LongName	frequency			attribute	
-N_Units	hertz	m		attribute	Unit of the values given in N
+N:LongName	frequency			attribute
+N:Units	hertz	m		attribute	Unit of the values given in N

--- a/API_MO/conventions/SimpleFreeFieldHRTF_2.0.csv
+++ b/API_MO/conventions/SimpleFreeFieldHRTF_2.0.csv
@@ -1,44 +1,44 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	2.0	rm	 	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	2.0	rm	 	attribute
 GLOBAL:SOFAConventions	SimpleFreeFieldHRTF	rm	  	attribute	This conventions is for HRTFs created under conditions where room information is irrelevant
-GLOBAL:SOFAConventionsVersion	2.0	rm	  	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Comment			 	attribute	
-GLOBAL:DataType	TF	rm	  	attribute	
-GLOBAL:History			 	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
+GLOBAL:SOFAConventionsVersion	2.0	rm	  	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Comment			 	attribute
+GLOBAL:DataType	TF	rm	  	attribute
+GLOBAL:History			 	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
 GLOBAL:ListenerShortName		m		attribute	ID of the subject from the database
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:References				attribute	
-GLOBAL:RoomType	free field	m	  	attribute	
-GLOBAL:Origin				attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:Title		m		attribute	
-ListenerPosition	[0 0 0] 	m	IC, MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	rCI, rCM	double	
-ReceiverPosition:Type	cartesian	m	  	attribute	
-ReceiverPosition:Units	metre	m	  	attribute	
+GLOBAL:Organization		m	  	attribute
+GLOBAL:References				attribute
+GLOBAL:RoomType	free field	m	  	attribute
+GLOBAL:Origin				attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:Title		m		attribute
+ListenerPosition	[0 0 0] 	m	IC, MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	rCI, rCM	double
+ReceiverPosition:Type	cartesian	m	  	attribute
+ReceiverPosition:Units	metre	m	  	attribute
 SourcePosition	[0 0 1]	m	IC, MC	double	Source position is assumed to vary for different directions/positions around the listener
-SourcePosition:Type	spherical	m	  	attribute	
-SourcePosition:Units	degree, degree, metre	m	  	attribute	
-EmitterPosition	[0 0 0]	m	eCI, eCM	double	
-EmitterPosition:Type	cartesian	m	  	attribute	
-EmitterPosition:Units	metre	m	  	attribute	
+SourcePosition:Type	spherical	m	  	attribute
+SourcePosition:Units	degree, degree, metre	m	  	attribute
+EmitterPosition	[0 0 0]	m	eCI, eCM	double
+EmitterPosition:Type	cartesian	m	  	attribute
+EmitterPosition:Units	metre	m	  	attribute
 GLOBAL:DatabaseName		m	  	attribute	name of the database to which these data belong
-ListenerUp	[0 0 1]	m	IC, MC	double	
-ListenerView	[1 0 0]	m	IC, MC	double	
-ListenerView:Type	cartesian	m		attribute	
-ListenerView:Units	metre	m		attribute	
-Data.Real	[0 0]	m	mRn	double	
-Data.Imag	[0 0]	m	MRN	double	
-N	0	m	N	double	
-N_LongName	frequency			attribute	
-N_Units	hertz			attribute	
+ListenerUp	[0 0 1]	m	IC, MC	double
+ListenerView	[1 0 0]	m	IC, MC	double
+ListenerView:Type	cartesian	m		attribute
+ListenerView:Units	metre	m		attribute
+Data.Real	[0 0]	m	mRn	double
+Data.Imag	[0 0]	m	MRN	double
+N	0	m	N	double
+N:LongName	frequency			attribute
+N:Units	hertz			attribute

--- a/API_MO/conventions/SingleRoomDRIR_0.3.csv
+++ b/API_MO/conventions/SingleRoomDRIR_0.3.csv
@@ -1,45 +1,45 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	1.0	rm	 	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	1.0	rm	 	attribute
 GLOBAL:SOFAConventions	SingleRoomDRIR	rm	  	attribute	This convention stores arbitrary number of receivers while providing an information about the room. The main application is to store DRIRs for a single room.
-GLOBAL:SOFAConventionsVersion	0.3	rm	  	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Comment		m	 	attribute	
-GLOBAL:DataType	FIR	rm	  	attribute	
-GLOBAL:History			 	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:References				attribute	
-GLOBAL:RoomType	reverberant	m	  	attribute	
-GLOBAL:Origin				attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:Title		m		attribute	
-ListenerPosition	[0 0 0] 	m	IC, MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ReceiverPosition	[0 0 0]	m	rCI, rCM	double	
-ReceiverPosition:Type	cartesian	m	  	attribute	
-ReceiverPosition:Units	metre	m	  	attribute	
-SourcePosition	[0 0 0]	m	IC, MC	double	
-SourcePosition:Type	cartesian	m	  	attribute	
-SourcePosition:Units	metre	m	  	attribute	
-EmitterPosition	[0 0 0]	m	eCI, eCM	double	
-EmitterPosition:Type	cartesian	m	  	attribute	
-EmitterPosition:Units	metre	m	  	attribute	
-GLOBAL:DatabaseName		m	  	attribute	
-GLOBAL:RoomDescription		m	  	attribute	
-ListenerUp	[0 0 1]	m	IC, MC	double	
-ListenerView	[1 0 0]	m	IC, MC	double	
-ListenerView:Type	cartesian	m		attribute	
-SourceUp	[0 0 1]	m	IC, MC	double	
-SourceView	[-1 0 0]	m	IC, MC	double	
-SourceView:Type	cartesian	m		attribute	
-Data.IR	[0 0]	m	mRn	double	
-Data.SamplingRate	48000	m	I	double	
-Data.SamplingRate:Units	hertz	m		attribute	
-Data.Delay	[0 0]	m	IR, MR	double	
+GLOBAL:SOFAConventionsVersion	0.3	rm	  	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Comment		m	 	attribute
+GLOBAL:DataType	FIR	rm	  	attribute
+GLOBAL:History			 	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:References				attribute
+GLOBAL:RoomType	reverberant	m	  	attribute
+GLOBAL:Origin				attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:Title		m		attribute
+ListenerPosition	[0 0 0] 	m	IC, MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ReceiverPosition	[0 0 0]	m	RCI, RCM	double
+ReceiverPosition:Type	cartesian	m	  	attribute
+ReceiverPosition:Units	metre	m	  	attribute
+SourcePosition	[0 0 0]	m	IC, MC	double
+SourcePosition:Type	cartesian	m	  	attribute
+SourcePosition:Units	metre	m	  	attribute
+EmitterPosition	[0 0 0]	m	eCI, eCM	double
+EmitterPosition:Type	cartesian	m	  	attribute
+EmitterPosition:Units	metre	m	  	attribute
+GLOBAL:DatabaseName		m	  	attribute
+GLOBAL:RoomDescription		m	  	attribute
+ListenerUp	[0 0 1]	m	IC, MC	double
+ListenerView	[1 0 0]	m	IC, MC	double
+ListenerView:Type	cartesian	m		attribute
+SourceUp	[0 0 1]	m	IC, MC	double
+SourceView	[-1 0 0]	m	IC, MC	double
+SourceView:Type	cartesian	m		attribute
+Data.IR	[0]	m	mrn	double
+Data.SamplingRate	48000	m	I	double
+Data.SamplingRate:Units	hertz	m		attribute
+Data.Delay	[0]	m	IR, MR	double

--- a/API_MO/conventions/SingleRoomMIMOSRIR_1.0.csv
+++ b/API_MO/conventions/SingleRoomMIMOSRIR_1.0.csv
@@ -1,67 +1,67 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	2.0	rm	 	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	2.0	rm	 	attribute
 GLOBAL:SOFAConventions	SingleRoomMIMOSRIR	rm	  	attribute	Single-room multiple-input multiple-output spatial room impulse responses, depending on Emitters
-GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute	
+GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute
 GLOBAL:DataType	FIR-E	rm	  	attribute	Shall be FIR-E
-GLOBAL:RoomType	shoebox	m	  	attribute	Shall be ‘shoebox’ or ‘dae’
-GLOBAL:Title		m		attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:Comment			 	attribute	
+GLOBAL:RoomType	shoebox	m	  	attribute	Shall be 'shoebox' or 'dae'
+GLOBAL:Title		m		attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:Comment			 	attribute
 GLOBAL:RoomDescription				attribute	narrative description of the room
-GLOBAL:History			 	attribute	
-GLOBAL:References				attribute	
-GLOBAL:Origin				attribute	
-GLOBAL:ListenerShortName				attribute	
-GLOBAL:ListenerDescription				attribute	
-ListenerPosition	[0 0 0] 	m	MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ListenerView	[1 0 0]	m	IC, MC	double	
-ListenerUp	[0 0 1]	m	IC, MC	double	
-ListenerView:Type	cartesian	m		attribute	
-ListenerView:Units	metre	m		attribute	
-GLOBAL:ReceiverShortName				attribute	
-GLOBAL:ReceiverDescription				attribute	
-ReceiverPosition	[0 0 0]	m	IC, RCI, RCM	double	
+GLOBAL:History			 	attribute
+GLOBAL:References				attribute
+GLOBAL:Origin				attribute
+GLOBAL:ListenerShortName				attribute
+GLOBAL:ListenerDescription				attribute
+ListenerPosition	[0 0 0] 	m	MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ListenerView	[1 0 0]	m	IC, MC	double
+ListenerUp	[0 0 1]	m	IC, MC	double
+ListenerView:Type	cartesian	m		attribute
+ListenerView:Units	metre	m		attribute
+GLOBAL:ReceiverShortName				attribute
+GLOBAL:ReceiverDescription				attribute
+ReceiverPosition	[0 0 0]	m	IC, RCI, RCM	double
 ReceiverPosition:Type	spherical	m	  	attribute	Can be of any type enabling both spatially discrete and spatially continuous representations.
-ReceiverPosition:Units	degree, degree, metre	m	  	attribute	
-ReceiverView	[1 0 0]		RCI, RCM	double	
-ReceiverUp	[0 0 1]		RCI, RCM	double	
-ReceiverView:Type	cartesian			attribute	
-ReceiverView:Units	metre			attribute	
-GLOBAL:SourceShortName				attribute	
-GLOBAL:SourceDescription				attribute	
-SourcePosition	[0 0 1]	m	MC	double	
-SourcePosition:Type	cartesian	m	  	attribute	
-SourcePosition:Units	metre	m	  	attribute	
-SourceView	[1 0 0]	m	IC, MC	double	
-SourceUp	[0 0 1]	m	IC, MC	double	
-SourceView:Type	cartesian	m		attribute	
-SourceView:Units	metre	m		attribute	
-GLOBAL:EmitterShortName				attribute	
-GLOBAL:EmitterDescription				attribute	
+ReceiverPosition:Units	degree, degree, metre	m	  	attribute
+ReceiverView	[1 0 0]		RCI, RCM	double
+ReceiverUp	[0 0 1]		RCI, RCM	double
+ReceiverView:Type	cartesian			attribute
+ReceiverView:Units	metre			attribute
+GLOBAL:SourceShortName				attribute
+GLOBAL:SourceDescription				attribute
+SourcePosition	[0 0 1]	m	MC	double
+SourcePosition:Type	cartesian	m	  	attribute
+SourcePosition:Units	metre	m	  	attribute
+SourceView	[1 0 0]	m	IC, MC	double
+SourceUp	[0 0 1]	m	IC, MC	double
+SourceView:Type	cartesian	m		attribute
+SourceView:Units	metre	m		attribute
+GLOBAL:EmitterShortName				attribute
+GLOBAL:EmitterDescription				attribute
 EmitterPosition	[0 0 0]	m	IC, ECI, ECM	double	Can be of any type enabling both spatially discrete and spatially continuous representations.
-EmitterPosition:Type	spherical	m	  	attribute	
-EmitterPosition:Units	degree, degree, metre	m	  	attribute	
-EmitterView	[1 0 0]		ECI, ECM	double	
-EmitterUp	[0 0 1]		ECI, ECM	double	
-EmiiterView:Type	cartesian			attribute	
-EmitterView:Units	metre			attribute	
+EmitterPosition:Type	spherical	m	  	attribute
+EmitterPosition:Units	degree, degree, metre	m	  	attribute
+EmitterView	[1 0 0]		ECI, ECM	double
+EmitterUp	[0 0 1]		ECI, ECM	double
+EmitterView:Type	cartesian			attribute
+EmitterView:Units	metre			attribute
 Data.IR	0	m	mrne	double	Impulse responses
 Data.SamplingRate	48000	m	I, M	double	Sampling rate of the samples in Data.IR and Data.Delay
 Data.SamplingRate:Units	hertz	m		attribute	Unit of the sampling rate
 Data.Delay	0	m	IRI, MRI, MRE	double	Additional delay of each IR (in samples)
-RoomCornerA	[0 0 0]	m	IC, MC	double	
-RoomCornerB	[1 2 3]	m	IC, MC	double	
-RoomCorners:Type	cartesian	m		attribute	
-RoomCorners:Units	metre	m		attribute	
+RoomCornerA	[0 0 0]	m	IC, MC	double
+RoomCornerB	[1 2 3]	m	IC, MC	double
+RoomCorners:Type	cartesian	m		attribute
+RoomCorners:Units	metre	m		attribute
 GLOBAL:DatabaseName		m		attribute	Name of the database. Used for classification of the data.

--- a/API_MO/conventions/SingleRoomSRIR_1.0.csv
+++ b/API_MO/conventions/SingleRoomSRIR_1.0.csv
@@ -1,67 +1,69 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm	  	attribute	
-GLOBAL:Version	2.0	rm	 	attribute	
-GLOBAL:SOFAConventions	SingleRoomSRIR	rm	  	attribute	For measuring SRIRs in a single room with a single excitation source (e.g., a loudspeaker) and a listener containing an arbitrary number of omnidirectional receivers (e.g., a microphone array). 
-GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute	
+GLOBAL:Conventions	SOFA	rm	  	attribute
+GLOBAL:Version	2.0	rm	 	attribute
+GLOBAL:SOFAConventions	SingleRoomSRIR	rm	  	attribute	For measuring SRIRs in a single room with a single excitation source (e.g., a loudspeaker) and a listener containing an arbitrary number of omnidirectional receivers (e.g., a microphone array).
+GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute
 GLOBAL:DataType	FIR	rm	  	attribute	Shall be FIR
-GLOBAL:RoomType	shoebox	m	  	attribute	Shall be ‘shoebox’ or ‘dae’
-GLOBAL:Title		m		attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:Comment			 	attribute	
+GLOBAL:RoomType	shoebox	m	  	attribute	Shall be 'shoebox' or 'dae'
+GLOBAL:Title		m		attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:Comment			 	attribute
 GLOBAL:RoomDescription				attribute	narrative description of the room
-GLOBAL:History			 	attribute	
-GLOBAL:References				attribute	
-GLOBAL:Origin				attribute	
-GLOBAL:ListenerShortName				attribute	
-GLOBAL:ListenerDescription				attribute	
-ListenerPosition	[0 0 0] 	m	MC	double	
-ListenerPosition:Type	cartesian	m	  	attribute	
-ListenerPosition:Units	metre	m	  	attribute	
-ListenerView	[1 0 0]	m	IC, MC	double	
-ListenerUp	[0 0 1]	m	IC, MC	double	
-ListenerView:Type	cartesian	m		attribute	
-ListenerView:Units	metre	m		attribute	
-GLOBAL:ReceiverShortName				attribute	
-GLOBAL:ReceiverDescription				attribute	
-ReceiverPosition	[0 0 0]	m	IC, RCI, RCM	double	
+GLOBAL:History			 	attribute
+GLOBAL:References				attribute
+GLOBAL:Origin				attribute
+GLOBAL:ListenerShortName				attribute
+GLOBAL:ListenerDescription				attribute
+ListenerPosition	[0 0 0] 	m	MC	double
+ListenerPosition:Type	cartesian	m	  	attribute
+ListenerPosition:Units	metre	m	  	attribute
+ListenerView	[1 0 0]	m	IC, MC	double
+ListenerUp	[0 0 1]	m	IC, MC	double
+ListenerView:Type	cartesian	m		attribute
+ListenerView:Units	metre	m		attribute
+GLOBAL:ReceiverShortName				attribute
+GLOBAL:ReceiverDescription				attribute
+ReceiverPosition	[0 0 0]	m	IC, RCI, RCM	double
 ReceiverPosition:Type	spherical	m	  	attribute	Can be of any type enabling both spatially discrete and spatially continuous representations.
-ReceiverPosition:Units	degree, degree, metre	m	  	attribute	
-ReceiverView	[1 0 0]		RCI, RCM	double	
-ReceiverUp	[0 0 1]		RCI, RCM	double	
-ReceiverView:Type	cartesian			attribute	
-ReceiverView:Units	metre			attribute	
-GLOBAL:SourceShortName				attribute	
-GLOBAL:SourceDescription				attribute	
-SourcePosition	[0 0 1]	m	MC	double	
-SourcePosition:Type	cartesian	m	  	attribute	
-SourcePosition:Units	metre	m	  	attribute	
-SourceView	[1 0 0]	m	IC, MC	double	
-SourceUp	[0 0 1]	m	IC, MC	double	
-SourceView:Type	cartesian	m		attribute	
-SourceView:Units	metre	m		attribute	
-GLOBAL:EmitterShortName				attribute	
-GLOBAL:EmitterDescription				attribute	
-EmitterPosition	[0 0 0]	m	eCI, eCM	double	
-EmitterPosition:Type	spherical	m	  	attribute	Shall be ‘cartesian’ or ‘spherical’, restricting to spatially discrete emitters.
-EmitterPosition:Units	degree, degree, metre	m	  	attribute	
-EmitterView	[1 0 0]		ECI, ECM	double	
-EmitterUp	[0 0 1]		ECI, ECM	double	
-EmiiterView:Type	cartesian			attribute	Shall be ‘cartesian’ or ‘spherical’, restricting to spatially discrete emitters.
-EmitterView:Units	metre			attribute	
+ReceiverPosition:Units	degree, degree, metre	m	  	attribute
+ReceiverView	[1 0 0]		RCI, RCM	double
+ReceiverUp	[0 0 1]		RCI, RCM	double
+ReceiverView:Type	cartesian			attribute
+ReceiverView:Units	metre			attribute
+GLOBAL:SourceShortName				attribute
+GLOBAL:SourceDescription				attribute
+SourcePosition	[0 0 1]	m	MC	double
+SourcePosition:Type	cartesian	m	  	attribute
+SourcePosition:Units	metre	m	  	attribute
+SourceView	[1 0 0]	m	IC, MC	double
+SourceUp	[0 0 1]	m	IC, MC	double
+SourceView:Type	cartesian	m		attribute
+SourceView:Units	metre	m		attribute
+GLOBAL:EmitterShortName				attribute
+GLOBAL:EmitterDescription				attribute
+EmitterPosition	[0 0 0]	m	eCI, eCM	double
+EmitterPosition:Type	spherical	m	  	attribute	Shall be 'cartesian' or 'spherical', restricting to spatially discrete emitters.
+EmitterPosition:Units	degree, degree, metre	m	  	attribute
+EmitterView	[1 0 0]		ECI, ECM	double
+EmitterUp	[0 0 1]		ECI, ECM	double
+EmitterView:Type	cartesian			attribute	Shall be 'cartesian' or 'spherical', restricting to spatially discrete emitters.
+EmitterView:Units	metre			attribute
 Data.IR	0	m	mrn	double	Impulse responses
 Data.SamplingRate	48000	m	I, M	double	Sampling rate of the samples in Data.IR and Data.Delay
 Data.SamplingRate:Units	hertz	m		attribute	Unit of the sampling rate
 Data.Delay	0	m	IR, MR	double	Additional delay of each IR (in samples)
-RoomCornerA	[0 0 0]		IC, MC	double	
-RoomCornerB	[1 2 3]		IC, MC	double	
-RoomCorners:Type	cartesian			attribute	
-RoomCorners:Units	metre			attribute	
+RoomCornerA	[0 0 0]		IC, MC	double
+RoomCornerA:Type	cartesian			attribute
+RoomCornerA:Units	metre			attribute
+RoomCornerB	[1 2 3]		IC, MC	double
+RoomCornerB:Type	cartesian			attribute
+RoomCornerB:Units	metre			attribute
 GLOBAL:DatabaseName		m		attribute	Name of the database. Used for classification of the data.


### PR DESCRIPTION
Proposed
----------

- Fixed a couple of inconsistencies in the csv convention files (see detailed list below).
- Replaced non-ASCII quotes by `'`
- Removed empty tabs at line ends (done automatically by my IDE. Sorry - this makes the diffs look a bit messi)

Test of changes
----------------
- SOFAstart.m still seems to create the mat convention files without throwing any errors
- I am currently writing a Python API for SOFA that uses the csv files from APIMO. As part of that, I wrote a round trip test that 1) creates SOFA files in Python, 2) writes them to disk, 3) reads them from disk and 4) compares the result to 3. This test discovered the inconsistencies and failed with the old csv files. The new files pass the test. This does not mean that the new files are free of errors, but they are consistent with respect to the things that I test.

Detailed list of changes
-----------------------

**FreeFieldDirectivityTF_1.0**
- EmitterDescription: change dimensions from 'IC, MS' to 'IS, MS' according to
  AES69
- SourceTuningFrequency: change default from ''  (empty string) to 440. This is a variable of
  type double. It can not have a string as default.

**FreeFieldHRTF_1.0, GeneralTF_1.0, GeneralTF_2.0, GeneralTF-E_1.0, SimpleFreeFieldHRTF_2.0**
- N_LongName, and N_Units: Change to N:LongName, and N:Units. Both fields are
  attributes which is otherwise denoted by Var:Attribute and not Var_Attribute

**GeneralFIR-E_2.0, GeneralTF-E**
- ReceiverPosition: Change from 'I, R, M, RM, RCI, RCM' to 'IC, RC, RCM'
  according to AES69, 4.7.4
- EmitterPosition: Change from 'I, E, M, EM, ECI, ECM' to 'IC, EC, ECM'
  according to AES69, 4.7.6

**GeneralFIR_2.0, GeneralTF_2.0**
- ReceiverPosition: Changed from 'I, R, IM, RM, RCI, RCM', to 'IC, RC, RCM' in
  analogy to GeneralFIR-E_2.0

**SingleRoomDRIR_0.3.csv**
- Data.IR and Data.Delay: Change default from '[0, 0]' to '[0]' because the
  ReceiverPosition only has one entry (We could also change the Receiver-
  Position, but this is the minimal example)
- Data.IR: Change dimensions from 'mRn' to 'mrn' according to AES69
- ReceiverPosition: Change dimension from 'rCI, 'rCM'' to 'RCI, RCM' according
  to AES69

**SingleRoomSRIR_1.0**
Has the attributes RoomCorners:Type and RoomCorners:Units but no variable of
the same name - variables are RoomCornerA and RoomCornerB
- removed idle attributes and created attributes RoomCornerA:*, and
  RoomCornerB*

**SingleRoomMimoSRIR_1.0, SingleRoomSRIR_1.0**
- Corrected type in EmiiterView:Type to EmitterView:Type
