### PR TITLE
update Room metadata

### DIFF
--- a/API_MO/conventions/MultiSpeakerBRIR_0.3.csv
+++ b/API_MO/conventions/MultiSpeakerBRIR_0.3.csv
@@ -3,41 +3,68 @@ GLOBAL:Conventions	SOFA	rm	  	attribute
 GLOBAL:Version	1.0	rm	 	attribute	
 GLOBAL:SOFAConventions	MultiSpeakerBRIR	rm	  	attribute	This convention is for BRIRs recorded in reverberant conditions from multiple loudspeaker sources at a number of listener orientations.
 GLOBAL:SOFAConventionsVersion	0.3	rm	  	attribute	
-GLOBAL:APIName		rm	  	attribute	
-GLOBAL:APIVersion		rm	  	attribute	
-GLOBAL:ApplicationName			  	attribute	
-GLOBAL:ApplicationVersion			  	attribute	
-GLOBAL:AuthorContact		m	  	attribute	
-GLOBAL:Comment		m	 	attribute	
 GLOBAL:DataType	FIRE	rm	  	attribute	We use FIR datatype which in addition depends on Emitters (E)
-GLOBAL:History			 	attribute	
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
-GLOBAL:Organization		m	  	attribute	
-GLOBAL:References				attribute	
 GLOBAL:RoomType	reverberant	m	  	attribute	
-GLOBAL:Origin				attribute	
-GLOBAL:DateCreated		m	 	attribute	
-GLOBAL:DateModified		m	 	attribute	
-GLOBAL:Title		m		attribute	
+GLOBAL:Title		m		attribute
+GLOBAL:DateCreated		m	 	attribute
+GLOBAL:DateModified		m	 	attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:Comment			 	attribute
+GLOBAL:History			 	attribute
+GLOBAL:References				attribute
+GLOBAL:Origin				attribute
+GLOBAL:DatabaseName		m		attribute	Name of the database. Used for classification of the data.
+GLOBAL:RoomShortName				attribute	Short name of the Room
+GLOBAL:RoomDescription				attribute	Informal verbal description of the room
+GLOBAL:RoomLocation				attribute	Location of the room
+GLOBAL:RoomGeometry				attribute	URI to a file describing the room geometry.
+RoomTemperature	0		I, M	double	Temperature during measurements
+RoomTemperature:Units	Kelvin			attribute	Units of the room temperature
+RoomVolume	0		I, M	double	Volume of the room
+RoomVolume:Units	cubic metre			attribute	Units of the room volume
+RoomCornerA	[0 0 0]		IC, MC	double
+RoomCornerB	[1 2 3]		IC, MC	double
+RoomCorners	0		II	double	The value of this attribute is to be ignored. It only exist to for RoomCorners:Type and RoomCorners:Units
+RoomCorners:Type	cartesian			attribute
+RoomCorners:Units	metre			attribute
+GLOBAL:ListenerShortName				attribute
+GLOBAL:ListenerDescription				attribute
 ListenerPosition	[0 0 0] 	m	IC, MC	double	
 ListenerPosition:Type	cartesian	m	  	attribute	
 ListenerPosition:Units	metre	m	  	attribute	
-ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	rCI, rCM	double	
-ReceiverPosition:Type	cartesian	m	  	attribute	
-ReceiverPosition:Units	metre	m	  	attribute	
-SourcePosition	[0 0 1]	m	IC, MC	double	
-SourcePosition:Type	spherical	m	  	attribute	
-SourcePosition:Units	degree, degree, metre	m	  	attribute	
-EmitterPosition	[0 0 0]	m	eCI, eCM	double	Each speaker is represented as an emitter. Use EmitterPosition to represent the position of a particular speaker. Size of EmitterPosition determines E
-EmitterPosition:Type	cartesian	m	  	attribute	
-EmitterPosition:Units	metre	m	  	attribute	
-GLOBAL:DatabaseName		m	  	attribute	name of the database to which these data belong
-GLOBAL:ListenerShortName		m	  	attribute	ID of the subject from the database
-GLOBAL:RoomDescription				attribute	narrative description of the room
 ListenerUp	[0 0 1]	m	IC, MC	double	
 ListenerView	[1 0 0]	m	IC, MC	double	
 ListenerView:Type	cartesian	m	  	attribute	
 ListenerView:Units	metre	m	  	attribute	
+GLOBAL:ReceiverShortName				attribute
+GLOBAL:ReceiverDescription				attribute
+ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	rCI, rCM	double	
+ReceiverPosition:Type	cartesian	m	  	attribute	
+ReceiverPosition:Units	metre	m	  	attribute
+ReceiverView	[1 0 0; 1 0 0]		RCI, RCM	double
+ReceiverUp	[0 0 1; 0 0 1]		RCI, RCM	double
+ReceiverView:Type	cartesian			attribute
+ReceiverView:Units	metre			attribute	
+GLOBAL:SourceShortName				attribute
+GLOBAL:SourceDescription				attribute
+SourcePosition	[0 0 1]	m	IC, MC	double	
+SourcePosition:Type	spherical	m	  	attribute	
+SourcePosition:Units	degree, degree, metre	m	  	attribute
+SourceView	[1 0 0]	m	IC, MC	double
+SourceUp	[0 0 1]	m	IC, MC	double
+SourceView:Type	cartesian	m		attribute
+SourceView:Units	metre	m		attribute	
+GLOBAL:EmitterShortName				attribute
+GLOBAL:EmitterDescription				attribute
+EmitterPosition	[0 0 0]	m	eCI, eCM	double	Each speaker is represented as an emitter. Use EmitterPosition to represent the position of a particular speaker. Size of EmitterPosition determines E
+EmitterPosition:Type	cartesian	m	  	attribute	
+EmitterPosition:Units	metre	m	  	attribute	
 EmitterUp	[0 0 1]		ECI, ECM	double	When EmitterUp provided, EmitterView must be provided as well
 EmitterView	[1 0 0]		ECI, ECM	double	When EmitterView provided, EmitterUp must be provided as well
 EmitterView:Type	cartesian		  	attribute	

--- a/API_MO/conventions/SingleRoomDRIR_0.3.csv
+++ b/API_MO/conventions/SingleRoomDRIR_0.3.csv
@@ -1,47 +1,75 @@
 Name	Default	Flags	Dimensions	Type	Comment
 GLOBAL:Conventions	SOFA	rm	  	attribute
-GLOBAL:Version	1.0	rm	 	attribute
+GLOBAL:Version	2.0	rm	 	attribute
 GLOBAL:SOFAConventions	SingleRoomDRIR	rm	  	attribute	This convention stores arbitrary number of receivers while providing an information about the room. The main application is to store DRIRs for a single room.
 GLOBAL:SOFAConventionsVersion	0.3	rm	  	attribute
-GLOBAL:APIName		rm	  	attribute
-GLOBAL:APIVersion		rm	  	attribute
-GLOBAL:ApplicationName			  	attribute
-GLOBAL:ApplicationVersion			  	attribute
-GLOBAL:AuthorContact		m	  	attribute
-GLOBAL:Comment		m	 	attribute
 GLOBAL:DataType	FIR	rm	  	attribute
-GLOBAL:History			 	attribute
-GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
-GLOBAL:Organization		m	  	attribute
-GLOBAL:References				attribute
 GLOBAL:RoomType	reverberant	m	  	attribute
-GLOBAL:Origin				attribute
+GLOBAL:Title		m		attribute
 GLOBAL:DateCreated		m	 	attribute
 GLOBAL:DateModified		m	 	attribute
-GLOBAL:Title		m		attribute
+GLOBAL:APIName		rm	  	attribute
+GLOBAL:APIVersion		rm	  	attribute
+GLOBAL:AuthorContact		m	  	attribute
+GLOBAL:Organization		m	  	attribute
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
+GLOBAL:ApplicationName			  	attribute
+GLOBAL:ApplicationVersion			  	attribute
+GLOBAL:Comment		m	 	attribute
+GLOBAL:History			 	attribute
+GLOBAL:References				attribute
+GLOBAL:Origin				attribute
+GLOBAL:DatabaseName		m	  	attribute
+GLOBAL:RoomShortName				attribute	Short name of the Room
+GLOBAL:RoomDescription				attribute	Informal verbal description of the room
+GLOBAL:RoomLocation				attribute	Location of the room
+GLOBAL:RoomGeometry				attribute	URI to a file describing the room geometry.
+RoomTemperature	0		I, M	double	Temperature during measurements
+RoomTemperature:Units	Kelvin			attribute	Units of the room temperature
+RoomVolume	0		I, M	double	Volume of the room
+RoomVolume:Units	cubic metre			attribute	Units of the room volume
+RoomCornerA	[0 0 0]		IC, MC	double
+RoomCornerB	[1 2 3]		IC, MC	double
+RoomCorners	0		II	double	The value of this attribute is to be ignored. It only exist to for RoomCorners:Type and RoomCorners:Units
+RoomCorners:Type	cartesian			attribute
+RoomCorners:Units	metre			attribute
+GLOBAL:ListenerShortName				attribute
+GLOBAL:ListenerDescription				attribute
 ListenerPosition	[0 0 0] 	m	IC, MC	double
 ListenerPosition:Type	cartesian	m	  	attribute
 ListenerPosition:Units	metre	m	  	attribute
-ReceiverPosition	[0 0 0]	m	RCI, RCM	double
-ReceiverPosition:Type	cartesian	m	  	attribute
-ReceiverPosition:Units	metre	m	  	attribute
-SourcePosition	[0 0 0]	m	IC, MC	double
-SourcePosition:Type	cartesian	m	  	attribute
-SourcePosition:Units	metre	m	  	attribute
-EmitterPosition	[0 0 0]	m	eCI, eCM	double
-EmitterPosition:Type	cartesian	m	  	attribute
-EmitterPosition:Units	metre	m	  	attribute
-GLOBAL:DatabaseName		m	  	attribute
-GLOBAL:RoomDescription		m	  	attribute
 ListenerUp	[0 0 1]	m	IC, MC	double
 ListenerView	[1 0 0]	m	IC, MC	double
 ListenerView:Type	cartesian	m		attribute
 ListenerView:Units	metre	m		attribute
+GLOBAL:ReceiverShortName				attribute
+GLOBAL:ReceiverDescription				attribute
+ReceiverPosition	[0 0 0]	m	RCI, RCM	double
+ReceiverPosition:Type	cartesian	m	  	attribute
+ReceiverPosition:Units	metre	m	  	attribute
+ReceiverView	[1 0 0]		RCI, RCM	double
+ReceiverUp	[0 0 1]		RCI, RCM	double
+ReceiverView:Type	cartesian			attribute
+ReceiverView:Units	metre			attribute
+GLOBAL:SourceShortName				attribute
+GLOBAL:SourceDescription				attribute
+SourcePosition	[0 0 0]	m	IC, MC	double
+SourcePosition:Type	cartesian	m	  	attribute
+SourcePosition:Units	metre	m	  	attribute
 SourceUp	[0 0 1]	m	IC, MC	double
 SourceView	[-1 0 0]	m	IC, MC	double
 SourceView:Type	cartesian	m		attribute
 SourceView:Units	metre	m		attribute
-Data.IR	[0]	m	mrn	double
+GLOBAL:EmitterShortName				attribute
+GLOBAL:EmitterDescription				attribute
+EmitterPosition	[0 0 0]	m	eCI, eCM	double
+EmitterPosition:Type	cartesian	m	  	attribute
+EmitterPosition:Units	metre	m	  	attribute
+EmitterView	[1 0 0]		ECI, ECM	double
+EmitterUp	[0 0 1]		ECI, ECM	double
+EmitterView:Type	cartesian			attribute
+EmitterView:Units	metre			attribute
+Data.IR	0	m	mrn	double	Impulse responses
 Data.SamplingRate	48000	m	I	double
 Data.SamplingRate:Units	hertz	m		attribute
-Data.Delay	[0]	m	IR, MR	double
+Data.Delay	0	m	IR, MR	double

--- a/API_MO/conventions/SingleRoomMIMOSRIR_1.0.csv
+++ b/API_MO/conventions/SingleRoomMIMOSRIR_1.0.csv
@@ -16,10 +16,23 @@ GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
 GLOBAL:ApplicationName			  	attribute
 GLOBAL:ApplicationVersion			  	attribute
 GLOBAL:Comment			 	attribute
-GLOBAL:RoomDescription				attribute	narrative description of the room
 GLOBAL:History			 	attribute
 GLOBAL:References				attribute
 GLOBAL:Origin				attribute
+GLOBAL:DatabaseName		m		attribute	Name of the database. Used for classification of the data.
+GLOBAL:RoomShortName				attribute	Short name of the Room
+GLOBAL:RoomDescription				attribute	Informal verbal description of the room
+GLOBAL:RoomLocation				attribute	Location of the room
+GLOBAL:RoomGeometry				attribute	URI to a file describing the room geometry.
+RoomTemperature	0		I, M	double	Temperature during measurements
+RoomTemperature:Units	Kelvin			attribute	Units of the room temperature
+RoomVolume	0		I, M	double	Volume of the room
+RoomVolume:Units	cubic metre			attribute	Units of the room volume
+RoomCornerA	[0 0 0]		IC, MC	double
+RoomCornerB	[1 2 3]		IC, MC	double
+RoomCorners	0		II	double	The value of this attribute is to be ignored. It only exist to for RoomCorners:Type and RoomCorners:Units
+RoomCorners:Type	cartesian			attribute
+RoomCorners:Units	metre			attribute
 GLOBAL:ListenerShortName				attribute
 GLOBAL:ListenerDescription				attribute
 ListenerPosition	[0 0 0] 	m	MC	double
@@ -31,6 +44,7 @@ ListenerView:Type	cartesian	m		attribute
 ListenerView:Units	metre	m		attribute
 GLOBAL:ReceiverShortName				attribute
 GLOBAL:ReceiverDescription				attribute
+ReceiverDescription	{''}		RS	string	Optional R-dependent version of the attribute ReceiverDescription
 ReceiverPosition	[0 0 0]	m	IC, RCI, RCM	double
 ReceiverPosition:Type	spherical	m	  	attribute	Can be of any type enabling both spatially discrete and spatially continuous representations.
 ReceiverPosition:Units	degree, degree, metre	m	  	attribute
@@ -49,6 +63,7 @@ SourceView:Type	cartesian	m		attribute
 SourceView:Units	metre	m		attribute
 GLOBAL:EmitterShortName				attribute
 GLOBAL:EmitterDescription				attribute
+EmitterDescription	{''}		ES	string	Optional E-dependent version of the EmitterDiscription
 EmitterPosition	[0 0 0]	m	IC, ECI, ECM	double	Can be of any type enabling both spatially discrete and spatially continuous representations.
 EmitterPosition:Type	spherical	m	  	attribute
 EmitterPosition:Units	degree, degree, metre	m	  	attribute
@@ -60,9 +75,3 @@ Data.IR	0	m	mrne	double	Impulse responses
 Data.SamplingRate	48000	m	I, M	double	Sampling rate of the samples in Data.IR and Data.Delay
 Data.SamplingRate:Units	hertz	m		attribute	Unit of the sampling rate
 Data.Delay	0	m	IRI, MRI, MRE	double	Additional delay of each IR (in samples)
-RoomCornerA	[0 0 0]	m	IC, MC	double
-RoomCornerB	[1 2 3]	m	IC, MC	double
-RoomCorners	0		II	double	The value of this attribute is to be ignored. It only exist to for RoomCorners:Type and RoomCorners:Units
-RoomCorners:Type	cartesian	m		attribute
-RoomCorners:Units	metre	m		attribute
-GLOBAL:DatabaseName		m		attribute	Name of the database. Used for classification of the data.

--- a/API_MO/conventions/SingleRoomSRIR_1.0.csv
+++ b/API_MO/conventions/SingleRoomSRIR_1.0.csv
@@ -16,10 +16,23 @@ GLOBAL:License	No license provided, ask the author for permission	m	  	attribute
 GLOBAL:ApplicationName			  	attribute
 GLOBAL:ApplicationVersion			  	attribute
 GLOBAL:Comment			 	attribute
-GLOBAL:RoomDescription				attribute	narrative description of the room
 GLOBAL:History			 	attribute
 GLOBAL:References				attribute
 GLOBAL:Origin				attribute
+GLOBAL:DatabaseName		m		attribute	Name of the database. Used for classification of the data.
+GLOBAL:RoomShortName				attribute	Short name of the Room
+GLOBAL:RoomDescription				attribute	Informal verbal description of the room
+GLOBAL:RoomLocation				attribute	Location of the room
+GLOBAL:RoomGeometry				attribute	URI to a file describing the room geometry.
+RoomTemperature	0		I, M	double	Temperature during measurements
+RoomTemperature:Units	Kelvin			attribute	Units of the room temperature
+RoomVolume	0		I, M	double	Volume of the room
+RoomVolume:Units	cubic metre			attribute	Units of the room volume
+RoomCornerA	[0 0 0]		IC, MC	double
+RoomCornerB	[1 2 3]		IC, MC	double
+RoomCorners	0		II	double	The value of this attribute is to be ignored. It only exist to for RoomCorners:Type and RoomCorners:Units
+RoomCorners:Type	cartesian			attribute
+RoomCorners:Units	metre			attribute
 GLOBAL:ListenerShortName				attribute
 GLOBAL:ListenerDescription				attribute
 ListenerPosition	[0 0 0] 	m	MC	double
@@ -60,9 +73,3 @@ Data.IR	0	m	mrn	double	Impulse responses
 Data.SamplingRate	48000	m	I, M	double	Sampling rate of the samples in Data.IR and Data.Delay
 Data.SamplingRate:Units	hertz	m		attribute	Unit of the sampling rate
 Data.Delay	0	m	IR, MR	double	Additional delay of each IR (in samples)
-RoomCornerA	[0 0 0]		IC, MC	double
-RoomCornerB	[1 2 3]		IC, MC	double
-RoomCorners	0		II	double	The value of this attribute is to be ignored. It only exist to for RoomCorners:Type and RoomCorners:Units
-RoomCorners:Type	cartesian			attribute	Type of coordinate system for RoomCornerA and RoomCornerB
-RoomCorners:Units	metre			attribute	Unit of coordinate system for RoomCornerA and RoomCornerB
-GLOBAL:DatabaseName		m		attribute	Name of the database. Used for classification of the data.


### PR DESCRIPTION
Variables (RoomVolume, RoomTemperature) and attributes (RoomLocation, RoomGeometry, RoomShorName) for the room object were updated. RoomCornerA and RoomCornerB are no longer mandatory, as they are not necessary when RoomType = 'dae'. Dimesnsion of ReviverDescription and EmitterDescription now dependent on R and E respectively.