### PR TITLE
Add Emitter- and ReceiverDescriptions

### DIFF
--- a/API_MO/conventions/SimpleHeadphoneIR_1.0.csv
+++ b/API_MO/conventions/SimpleHeadphoneIR_1.0.csv
@@ -45,7 +45,7 @@ GLOBAL:SourceModel		m		attribute	Name of the headphone model. Must uniquely desc
 SourceModel	{''}		MS	string	Optional M-dependent version of the attribute SourceModel
 GLOBAL:SourceURI		m		attribute	URI of the headphone specifications
 GLOBAL:ReceiverDescription		m		attribute	Narrative description of the microphones
-ReceiverDescription	{''}		MS	string	Optional M-dependent version of the attribute ReceiverDescription
+ReceiverDescriptions	{''}		RS	string	R-dependent version of the attribute ReceiverDescription
 GLOBAL:EmitterDescription		m		attribute	Narrative description of the headphone drivers
-EmitterDescription	{''}		MS	string	Optional M-dependent version of the attribute EmitterDescription
+EmitterDescriptions	{''}		ES	string	E-dependent version of the attribute EmitterDescription
 MeasurementDate	0		M	double	Optional M-dependent date and time of the measurement

--- a/API_MO/conventions/SingleRoomMIMOSRIR_1.0.csv
+++ b/API_MO/conventions/SingleRoomMIMOSRIR_1.0.csv
@@ -31,6 +31,7 @@ ListenerView:Type	cartesian	m		attribute
 ListenerView:Units	metre	m		attribute
 GLOBAL:ReceiverShortName				attribute
 GLOBAL:ReceiverDescription				attribute
+ReceiverDescriptions	{''}		RS	string	R-dependent version of the attribute ReceiverDescription
 ReceiverPosition	[0 0 0]	m	IC, RCI, RCM	double
 ReceiverPosition:Type	spherical	m	  	attribute	Can be of any type enabling both spatially discrete and spatially continuous representations.
 ReceiverPosition:Units	degree, degree, metre	m	  	attribute
@@ -49,6 +50,7 @@ SourceView:Type	cartesian	m		attribute
 SourceView:Units	metre	m		attribute
 GLOBAL:EmitterShortName				attribute
 GLOBAL:EmitterDescription				attribute
+EmitterDescriptions	{''}		ES	string	E-dependent version of the attribute EmitterDescription
 EmitterPosition	[0 0 0]	m	IC, ECI, ECM	double	Can be of any type enabling both spatially discrete and spatially continuous representations.
 EmitterPosition:Type	spherical	m	  	attribute
 EmitterPosition:Units	degree, degree, metre	m	  	attribute

--- a/API_MO/conventions/SingleRoomSRIR_1.0.csv
+++ b/API_MO/conventions/SingleRoomSRIR_1.0.csv
@@ -31,6 +31,7 @@ ListenerView:Type	cartesian	m		attribute
 ListenerView:Units	metre	m		attribute
 GLOBAL:ReceiverShortName				attribute
 GLOBAL:ReceiverDescription				attribute
+ReceiverDescriptions	{''}		RS	string	R-dependent version of the attribute ReceiverDescription
 ReceiverPosition	[0 0 0]	m	IC, RCI, RCM	double
 ReceiverPosition:Type	spherical	m	  	attribute	Can be of any type enabling both spatially discrete and spatially continuous representations.
 ReceiverPosition:Units	degree, degree, metre	m	  	attribute
@@ -49,6 +50,7 @@ SourceView:Type	cartesian	m		attribute
 SourceView:Units	metre	m		attribute
 GLOBAL:EmitterShortName				attribute
 GLOBAL:EmitterDescription				attribute
+EmitterDescriptions	{''}		ES	string	E-dependent version of the attribute EmitterDescription
 EmitterPosition	[0 0 0]	m	eCI, eCM	double
 EmitterPosition:Type	spherical	m	  	attribute	Shall be 'cartesian' or 'spherical', restricting to spatially discrete emitters.
 EmitterPosition:Units	degree, degree, metre	m	  	attribute


### PR DESCRIPTION
E-dependent version of the attribute EmitterDescription with specific descriptions of the emitters and R-dependent version of the attribute ReceiverDescription added and fixed in SimpleHeadphoneIR.