### PR TITLE
Spelling of SI units

### DIFF
--- a/API_MO/SOFAconvertConventions.m
+++ b/API_MO/SOFAconvertConventions.m
@@ -1,16 +1,16 @@
 function Obj=SOFAconvertConventions(Obj,varargin)
 % Obj = SOFAconvertConventions(Obj) converts a SOFA object to SimpleFreeFieldHRIR
-%   
-%  Supported conventions: 
+%
+%  Supported conventions:
 %    SimpleFreeFieldSOS
 %    SimpleFreeFieldTF
 %    SimpleFreeFieldHRTF
 %    FreeFieldHRTF
 %    some special cases of GeneralTF, GeneralTF-E.
-% 
+%
 % When using optional input values, they are transferred to and must be supported by SOFAarghelper function:
 %   Obj=SOFAconvertConventions(Obj,varargin)
-% 
+%
 
 % #Author: Piotr Majdak
 % #Author: Michael Mihocic: header documentation updated (28.10.2021)
@@ -20,13 +20,13 @@ function Obj=SOFAconvertConventions(Obj,varargin)
 % You may not use this work except in compliance with the License.
 % You may obtain a copy of the License at: https://joinup.ec.europa.eu/software/page/eupl
 % Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing  permissions and limitations under the License. 
+% See the License for the specific language governing  permissions and limitations under the License.
 
 %% get convention to be converted
 if ~isempty(varargin)
     definput.flags.convention=SOFAgetConventions();
     definput.flags.convention=strrep(definput.flags.convention,'-','_');
-    
+
     if contains(varargin,'-')
         varargin=strrep(varargin,'-','_');
     end
@@ -40,7 +40,7 @@ if ~isempty(varargin)
     if isempty( SOFAgetConventions(newConvention))
        error([newConvention, ' not a valid convention.'])
     end
-else 
+else
     newConvention = 'SimpleFreeFieldHRIR';
 end
 oldConvention = Obj.GLOBAL_SOFAConventions;
@@ -64,7 +64,7 @@ try
             if strcmp(newObj.GLOBAL_DataType,'SOS')
                  % no data conversion needed
             elseif strcmp(newObj.GLOBAL_DataType,'FIR')
-                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;   
+                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;
                 N=512;
                 impulse=[1; zeros(N-1,1)];
                 Obj.API.Dimensions.Data.IR=Obj.API.Dimensions.Data.SOS;
@@ -77,7 +77,7 @@ try
                 Obj.Data=rmfield(Obj.Data,'SOS');
                 Obj.API.Dimensions.Data=rmfield(Obj.API.Dimensions.Data,'SOS');
             elseif strcmp(newObj.GLOBAL_DataType,'TF')
-                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;   
+                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;
                 N=512;
                 impulse=[1; zeros(N-1,1)];
                 Obj.API.Dimensions.Data.IR=Obj.API.Dimensions.Data.SOS;
@@ -100,7 +100,7 @@ try
                 end
                 Obj.API.Dimensions.Data=rmfield(Obj.API.Dimensions.Data,'SOS');
             elseif strcmp(newObj.GLOBAL_DataType,'TF-E')
-                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;   
+                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;
                 N=512;
                 impulse=[1; zeros(N-1,1)];
                 Obj.API.Dimensions.Data.IR=Obj.API.Dimensions.Data.SOS;
@@ -126,7 +126,7 @@ try
 
                 Obj.API.E=Obj.API.M;
                 Obj.API.M=1;
-                realBuffer=shiftdim(Obj.Data.Real,1); 
+                realBuffer=shiftdim(Obj.Data.Real,1);
                 Obj.Data.Real=zeros(1,Obj.API.R,Obj.API.N,Obj.API.E);
                 Obj.Data.Real(1,:,:,:)=realBuffer;% MRN --> 1RNM --> MRNE with M=1
                 Obj.API.Dimensions.Data.Real='MRNE';
@@ -163,7 +163,7 @@ try
                 % TODO
                 error('Not supported yet')
             elseif strcmp(newObj.GLOBAL_DataType,'FIR')
-                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;   
+                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;
                 if sum(diff(diff(Obj.N)))
                   fs=max(Obj.N)*2;  % irregular grid, find the smallest frequency difference
                   N=fs/min([min(diff(Obj.N)) Obj.N(1)]);
@@ -178,7 +178,7 @@ try
                 end
                 Obj.API.Dimensions.Data.IR=Obj.API.Dimensions.Data.Real;
                 Obj.Data.SamplingRate=fs;
-                Obj.Data.SamplingRate_Units='Hertz';
+                Obj.Data.SamplingRate_Units='hertz';
                 Obj.Data.IR=zeros(Obj.API.M, Obj.API.R, N);
                 for ii=1:Obj.API.M
                   for jj=1:Obj.API.R
@@ -195,14 +195,14 @@ try
                 Obj.Data=rmfield(Obj.Data,{'Real','Imag'});
                 if isfield(Obj.API.Dimensions,'Data')
                     Obj.API.Dimensions.Data=rmfield(Obj.API.Dimensions.Data,{'Real','Imag'});
-                end    
-            elseif strcmp(newObj.GLOBAL_DataType,'TF') 
-                 % no data conversion needed    
+                end
+            elseif strcmp(newObj.GLOBAL_DataType,'TF')
+                 % no data conversion needed
             elseif strcmp(newObj.GLOBAL_DataType,'TF-E')
                 Obj.GLOBAL_DataType = newObj.GLOBAL_DataType;
                 Obj.API.E=Obj.API.M;
                 Obj.API.M=1;
-                realBuffer=shiftdim(Obj.Data.Real,1); 
+                realBuffer=shiftdim(Obj.Data.Real,1);
                 Obj.Data.Real=zeros(1,Obj.API.R,Obj.API.N,Obj.API.E);
                 Obj.Data.Real(1,:,:,:)=realBuffer;% MRN --> 1RNM --> MRNE with M=1
                 Obj.API.Dimensions.Data.Real='MRNE';
@@ -233,17 +233,17 @@ try
                 Obj.EmitterPosition_Type='Spherical Harmonics';
                 Obj.EmitterPosition_Units='Metre';
             end
-                
+
 
         case 'TF-E'
             if strcmp(newObj.GLOBAL_DataType,'SOS')
                 % TODO
                 error('Not supported yet')
             elseif strcmp(newObj.GLOBAL_DataType,'FIR')
-                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;   
+                Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;
                 Obj.API.Dimensions.Data.IR=Obj.API.Dimensions.Data.Real;
                 Obj.Data.SamplingRate=max(Obj.N)*2;
-                Obj.Data.SamplingRate_Units='Hertz';
+                Obj.Data.SamplingRate_Units='hertz';
                 % convert sperical harmonics
                 if strcmpi(Obj.EmitterPosition_Type,'spherical harmonics')
                     [X,Y,Z]=sphere(60);
@@ -260,7 +260,7 @@ try
                     Obj.API.M=size(S,1);
                     Obj.SourcePosition=[azi ele radius];
                     Obj.SourcePosition_Type='spherical';
-                    Obj.SourcePosition_Units='degrees,degrees,metre';    
+                    Obj.SourcePosition_Units='degrees,degrees,metre';
 
                     Data.Real = zeros(Obj.API.M,2,Obj.API.N);
                     Data.Imag = zeros(Obj.API.M,2,Obj.API.N);
@@ -306,12 +306,12 @@ try
                 Obj.Data.SamplingRate=fs;
                 Obj=rmfield(Obj,{'N','N_LongName','N_Units'});
                 Obj.Data=rmfield(Obj.Data,{'Real','Imag'});
-                Obj.API.Dimensions.Data=rmfield(Obj.API.Dimensions.Data,{'Real','Imag'});    
+                Obj.API.Dimensions.Data=rmfield(Obj.API.Dimensions.Data,{'Real','Imag'});
             elseif strcmp(newObj.GLOBAL_DataType,'TF')
                 Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;
                 % convert sperical harmonics
                 if strcmpi(Obj.EmitterPosition_Type,'harmonics')
-                    [X,Y,Z]=sphere(60); 
+                    [X,Y,Z]=sphere(60);
                     [azi_rad,ele_rad,radius]=cart2sph(X,Y,Z);
                     azi=azi_rad/pi*180;
                     ele=ele_rad/pi*180;
@@ -320,13 +320,13 @@ try
                     azi=azi(:);
                     ele=ele(:);
                     radius=radius(:);
-                    
+
                     S = sph2SH([azi ele], sqrt(Obj.API.E)-1);
                     Obj.API.M=size(S,1);
                     Obj.SourcePosition=radius;
                     Obj.SourcePosition_Type='spherical harmonics';
-                    Obj.SourcePosition_Units='metre'; 
-                    
+                    Obj.SourcePosition_Units='metre';
+
                     oldObj.Data.Real = Obj.Data.Real;
                     oldObj.Data.Imag = Obj.Data.Imag;
                     Obj.Data.Real = zeros(Obj.API.M,2,Obj.API.N);
@@ -345,7 +345,7 @@ try
             elseif strcmp(newObj.GLOBAL_DataType,'TF-E')
                  % no data conversion needed
             end
-            
+
         case 'FIR'
             if strcmp(newObj.GLOBAL_DataType,'SOS')
                 % TODO
@@ -369,7 +369,7 @@ try
                         Obj.Data.Real(ii,jj,:)=real(TF);
                         Obj.Data.Imag(ii,jj,:)=imag(TF);
                     end
-                end  
+                end
             elseif strcmp(newObj.GLOBAL_DataType,'TF-E')
                 Obj.GLOBAL_DataType=newObj.GLOBAL_DataType;
                 IR=Obj.Data.IR;
@@ -387,12 +387,12 @@ try
                         Obj.Data.Real(ii,jj,:)=real(TF);
                         Obj.Data.Imag(ii,jj,:)=imag(TF);
                     end
-                end  
+                end
                 Obj=SOFAupdateDimensions(Obj);
 
                 Obj.API.E=Obj.API.M;
                 Obj.API.M=1;
-                realBuffer=shiftdim(Obj.Data.Real,1); 
+                realBuffer=shiftdim(Obj.Data.Real,1);
                 Obj.Data.Real=zeros(1,Obj.API.R,Obj.API.N,Obj.API.E);
                 Obj.Data.Real(1,:,:,:)=realBuffer;% MRN --> 1RNM --> MRNE with M=1
                 Obj.API.Dimensions.Data.Real='MRNE';
@@ -422,7 +422,7 @@ try
                 Obj.EmitterPosition=mean(Obj.EmitterPosition(:,3));
                 Obj.EmitterPosition_Type='Spherical Harmonics';
                 Obj.EmitterPosition_Units='Metre';
-            end    
+            end
         otherwise
             error(['Turning ',oldConvention,' into ',...
                 newObj.GLOBAL_SOFAConventions,' not supported.']);

--- a/API_MO/conventions/FreeFieldDirectivityTF_1.0.csv
+++ b/API_MO/conventions/FreeFieldDirectivityTF_1.0.csv
@@ -1,58 +1,58 @@
 Name	Default	Flags	Dimensions	Type	Comment
-GLOBAL:Conventions	SOFA	rm		attribute	
-GLOBAL:Version	2.0	rm		attribute	
+GLOBAL:Conventions	SOFA	rm		attribute
+GLOBAL:Version	2.0	rm		attribute
 GLOBAL:SOFAConventions	FreeFieldDirectivityTF	rm		attribute	This conventions stores directivities of acoustic sources (instruments, loudspeakers, singers, talkers, etc) in the frequency domain for multiple musical notes in free field.
-GLOBAL:SOFAConventionsVersion	1.0	rm		attribute	
+GLOBAL:SOFAConventionsVersion	1.0	rm		attribute
 GLOBAL:DataType	TF	rm		attribute	We store frequency-dependent data here
 GLOBAL:RoomType	free field	m		attribute	The room information can be arbitrary, but the spatial setup assumes free field.
-GLOBAL:Title		m		attribute	
-GLOBAL:DateCreated		m		attribute	
-GLOBAL:DateModified		m		attribute	
-GLOBAL:APIName		rm		attribute	
-GLOBAL:APIVersion		rm		attribute	
-GLOBAL:AuthorContact		m		attribute	
-GLOBAL:Organization		m		attribute	
-GLOBAL:License	No license provided, ask the author for permission	m		attribute	
-GLOBAL:ApplicationName				attribute	
-GLOBAL:ApplicationVersion				attribute	
-GLOBAL:Comment		m		attribute	
-GLOBAL:History				attribute	
-GLOBAL:References				attribute	
-GLOBAL:Origin				attribute	
+GLOBAL:Title		m		attribute
+GLOBAL:DateCreated		m		attribute
+GLOBAL:DateModified		m		attribute
+GLOBAL:APIName		rm		attribute
+GLOBAL:APIVersion		rm		attribute
+GLOBAL:AuthorContact		m		attribute
+GLOBAL:Organization		m		attribute
+GLOBAL:License	No license provided, ask the author for permission	m		attribute
+GLOBAL:ApplicationName				attribute
+GLOBAL:ApplicationVersion				attribute
+GLOBAL:Comment		m		attribute
+GLOBAL:History				attribute
+GLOBAL:References				attribute
+GLOBAL:Origin				attribute
 GLOBAL:DatabaseName		m		attribute	Name of the database. Used for classification of the data
 GLOBAL:Musician				attribute	Narrative description of the musician such as position, behavior, or personal data if not data-protected, e.g., 'Christiane Schmidt sitting on the chair', or 'artificial excitation by R2D2'.
 GLOBAL:Description				attribute	Narrative description of a measurement. For musical instruments/singers, the note (C1, D1, etc) or the dynamic (pp., ff., etc), or the string played, the playing style (pizzicato, legato, etc.), or the type of excitation (e.g., hit location of a cymbal). For loudspeakers, the system and driver units.
 GLOBAL:SourceType		m		attribute	Narrative description of the acoustic source, e.g., 'Violin', 'Female singer', or '2-way loudspeaker'
 GLOBAL:SourceManufacturer		m		attribute	Narrative description of the manufacturer of the source, e.g., 'Stradivari, Lady Blunt, 1721' or 'LoudspeakerCompany'
 ListenerPosition	[0 0 0] 	m	IC, MC	double	Position of the microphone array during the measurements.
-ListenerPosition:Type	cartesian	m		attribute	
-ListenerPosition:Units	metre	m		attribute	
+ListenerPosition:Type	cartesian	m		attribute
+ListenerPosition:Units	metre	m		attribute
 ListenerView	[1 0 0]	m	IC, MC	double	Orientation of the microphone array
-ListenerView:Type	cartesian	m		attribute	
-ListenerView:Units	metre	m		attribute	
+ListenerView:Type	cartesian	m		attribute
+ListenerView:Units	metre	m		attribute
 ListenerUp	[0 0 1]	m	IC, MC	double	Up vector of the microphone array
 ReceiverPosition	[0 0 1]	m	IC, RC, RCM	double	Positions of the microphones during the measurements (relative to the Listener)
-ReceiverPosition:Type	spherical	m		attribute	
-ReceiverPosition:Units	degree, degree, metre	m		attribute	
+ReceiverPosition:Type	spherical	m		attribute
+ReceiverPosition:Units	degree, degree, metre	m		attribute
 SourcePosition	[0 0 0] 	m	IC, MC	double	Position of the acoustic source (instrument)
-SourcePosition:Type	cartesian	m		attribute	
-SourcePosition:Units	metre	m		attribute	
+SourcePosition:Type	cartesian	m		attribute
+SourcePosition:Units	metre	m		attribute
 SourcePosition:Reference		m		attribute	Narrative description of the spatial reference of the source position, e.g., for the trumpet, 'The bell'. Mandatory in order to provide a reference across different instruments
 SourceView	[1 0 0]	m	IC, MC	double	Orientation of the acoustic source (instrument)
-SourceView:Type	cartesian	m		attribute	
-SourceView:Units	metre	m		attribute	
+SourceView:Type	cartesian	m		attribute
+SourceView:Units	metre	m		attribute
 SourceView:Reference		m		attribute	Narrative description of the spatial reference of the source view, e.g., for the trumpet, 'Viewing direction of the bell'. Mandatory in order to provide a reference across different instruments
 SourceUp	[0 0 1]	m	IC, MC	double	Up vector of the acoustic source (instrument)
 SourceUp:Reference		m		attribute	Narrative description of the spatial reference of the source up, e.g., for the trumpet, 'Along the keys, keys up'. Mandatory in order to provide a reference across different instruments
 EmitterPosition	[0 0 0]	m	IC, MC	double	A more detailed structure of the Source. In a simple settings, a single Emitter is considered that is collocated with the source.
-EmitterPosition:Type	cartesian	m		attribute	
-EmitterPosition:Units	metre	m		attribute	
+EmitterPosition:Type	cartesian	m		attribute
+EmitterPosition:Units	metre	m		attribute
 EmitterDescription	{''}		IS, MS	string	A more detailed structure of the source. In a simple setting, a single Emitter is considered that is collocated with the source. In a more complicated setting, this may be the strings of a violin or the units of a loudspeaker.
 MIDINote	0		I, M	double	Defines the note played by the source during the measurement. The note is specified a MIDI note by the [https://www.midi.org/specifications-old/item/the-midi-1-0-specification MIDI specifications, version 1.0]. Not mandatory, but recommended for tonal instruments.
 Description	{''}		MS	string	This variable is used when the description varies with M.
-SourceTuningFrequency	440		I, M	double	Frequency (in Hertz) to which a musical instrument is tuned to corresponding to the note A4 (MIDINote=69). Recommended for tonal instruments.
+SourceTuningFrequency	440		I, M	double	Frequency (in hertz) to which a musical instrument is tuned to corresponding to the note A4 (MIDINote=69). Recommended for tonal instruments.
 Data.Real	0	m	mrn	double	Real part of the complex spectrum. The default value 0 indicates that all data fields are initialized with zero values.
 Data.Imag	0	m	MRN	double	Imaginary part of the complex spectrum
 N	0	m	N	double	Frequency values
-N:LongName	frequency	m		attribute	
+N:LongName	frequency	m		attribute
 N:Units	hertz	m		attribute	Units used for N

--- a/API_MO/conventions/SingleRoomMIMOSRIR_1.0.csv
+++ b/API_MO/conventions/SingleRoomMIMOSRIR_1.0.csv
@@ -25,7 +25,7 @@ GLOBAL:RoomDescription				attribute	Informal verbal description of the room
 GLOBAL:RoomLocation				attribute	Location of the room
 GLOBAL:RoomGeometry				attribute	URI to a file describing the room geometry.
 RoomTemperature	0		I, M	double	Temperature during measurements
-RoomTemperature:Units	Kelvin			attribute	Units of the room temperature
+RoomTemperature:Units	kelvin			attribute	Units of the room temperature
 RoomVolume	0		I, M	double	Volume of the room
 RoomVolume:Units	cubic metre			attribute	Units of the room volume
 RoomCornerA	[0 0 0]		IC, MC	double

--- a/API_MO/conventions/SingleRoomSRIR_1.0.csv
+++ b/API_MO/conventions/SingleRoomSRIR_1.0.csv
@@ -25,7 +25,7 @@ GLOBAL:RoomDescription				attribute	Informal verbal description of the room
 GLOBAL:RoomLocation				attribute	Location of the room
 GLOBAL:RoomGeometry				attribute	URI to a file describing the room geometry.
 RoomTemperature	0		I, M	double	Temperature during measurements
-RoomTemperature:Units	Kelvin			attribute	Units of the room temperature
+RoomTemperature:Units	kelvin			attribute	Units of the room temperature
 RoomVolume	0		I, M	double	Volume of the room
 RoomVolume:Units	cubic metre			attribute	Units of the room volume
 RoomCornerA	[0 0 0]		IC, MC	double


### PR DESCRIPTION
SI units should be written in lower-case:

https://www.nist.gov/pml/weights-and-measures/metric-si/si-units
https://en.wikipedia.org/wiki/International_System_of_Units

I discussed this with Piotr via Mail and we agreed to also change this in the AES69-2022 draft.

Sorry again for the auto-removal of trailing spaces. The only changes are:
- write `kelvin` instead of `Kelvin`
- write `hertz` instead of `Hertz`

This should now be unified everywhere in API_MO